### PR TITLE
Enhance documentation for molecule metadata retrieval

### DIFF
--- a/docs/src/contrib/addingMolecule.rst
+++ b/docs/src/contrib/addingMolecule.rst
@@ -52,7 +52,14 @@ Please ensure that the InChI represents your molecule. The named tools might del
 imperfect results. Provided your molecule is not fully synthetic or novel, you can
 obtain most of the other metadata from the `PubChem API
 <https://pubchem.ncbi.nlm.nih.gov/docs/pug-rest>`_ and the `UniChem API
-<https://www.ebi.ac.uk/unichem/api/docs>`_ using the InChIKey. Mapping especially to
+<https://www.ebi.ac.uk/unichem/api/docs>`_ using the InChIKey. 
+
+The ``AutocompleteMetadata``
+<https://github.com/NMRLipids/BilayerData/workflows/AutocompleteMetadata.yml>`_ will 
+add information from these APIs to your PR, as long as you provide an ``InChIKey`` as
+a suggestions.
+
+Mapping especially to
 LIPID MAPS and SwissLipids might be incomplete in some cases and can be completed
 manually.
 

--- a/docs/src/contrib/addingMolecule.rst
+++ b/docs/src/contrib/addingMolecule.rst
@@ -54,10 +54,10 @@ obtain most of the other metadata from the `PubChem API
 <https://pubchem.ncbi.nlm.nih.gov/docs/pug-rest>`_ and the `UniChem API
 <https://www.ebi.ac.uk/unichem/api/docs>`_ using the InChIKey. 
 
-The ``AutocompleteMetadata``
-<https://github.com/NMRLipids/BilayerData/workflows/AutocompleteMetadata.yml>`_ will 
-add information from these APIs to your PR, as long as you provide an ``InChIKey`` as
-a suggestions.
+The `AutocompleteMetadata workflow
+<https://github.com/NMRLipids/BilayerData/actions/workflows/AutocompleteMetadata.yml>`_
+will add information from these APIs to your PR, as long as you provide an ``InChIKey`` as
+a suggestion.
 
 Mapping especially to
 LIPID MAPS and SwissLipids might be incomplete in some cases and can be completed


### PR DESCRIPTION
Added information about AutocompleteMetadata and its usage with InChIKey for API integration.

<!-- readthedocs-preview databank start -->
----
📚 Documentation preview 📚: https://databank--517.org.readthedocs.build/

<!-- readthedocs-preview databank end -->